### PR TITLE
Fix env parser comment handling

### DIFF
--- a/backend/services/settings-service.js
+++ b/backend/services/settings-service.js
@@ -18,8 +18,8 @@ async function readEnvFile() {
     // Parse the content into key-value pairs
     const envVars = {};
     content.split('\n').forEach(line => {
-      // Skip comments and empty lines
-      if (line.trim() && !line.trim().startsWith('//')) {
+      // Skip empty lines and lines starting with // or #
+      if (line.trim() && !line.trim().startsWith('//') && !line.trim().startsWith('#')) {
         const parts = line.split('=');
         if (parts.length >= 2) {
           const key = parts[0].trim();


### PR DESCRIPTION
## Summary
- ignore `#` comment lines when reading .env files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848dd9bc1f08327afac8f23b2c44c0b